### PR TITLE
Add the replace_error function

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "snag"
-version = "1.1.0"
+version = "1.2.0"
 licences = ["Apache-2.0"]
 description = "A boilerplate-free ad-hoc error type"
 

--- a/src/snag.gleam
+++ b/src/snag.gleam
@@ -86,10 +86,12 @@ pub fn context(result: Result(success), issue: String) -> Result(success) {
   }
 }
 
-/// Maps the error type in a `Result` to a `Snag` given a describing function.
-/// The describing function should produce a human friendly string
+/// Map the error type in a `Result` to a `Snag` with the given describing
+/// function.
+///
+/// The describing function should produce a human friendly text
 /// reprensentation of the error.
-/// 
+///
 /// ### Example
 ///
 /// ```gleam
@@ -106,6 +108,32 @@ pub fn map_error(
   case result {
     Ok(a) -> Ok(a)
     Error(b) -> describer(b) |> error
+  }
+}
+
+/// Replace the error type in a `Result` with a `Snag` with the given
+/// issue text.
+///
+/// This is especially useful for converting functions that return a `Nil`
+/// error into a `Snag`. Always prefer using the `map_error` function for
+/// non `Nil` errors when possible.
+///
+/// ### Example
+///
+/// ```gleam
+/// dict.get(users, "user_id")
+/// |> snag.replace_error("User not found in dict")
+/// |> snag.context("Could not get user data")
+/// |> snag.line_print
+/// // -> "error: Could not get user data <- User not found in dict"
+/// ```
+pub fn replace_error(
+  result: gleam.Result(a, b),
+  with issue: String,
+) -> Result(a) {
+  case result {
+    Ok(a) -> Ok(a)
+    Error(_) -> error(issue)
   }
 }
 

--- a/test/snag_test.gleam
+++ b/test/snag_test.gleam
@@ -58,3 +58,15 @@ pub fn map_error_ok_test() {
   |> snag.context("Could not open file")
   |> should.equal(Ok(0))
 }
+
+pub fn replace_error_error_test() {
+  Error(Nil)
+  |> snag.replace_error("Could not open file")
+  |> should.equal(Error(Snag("Could not open file", [])))
+}
+
+pub fn replace_error_ok_test() {
+  Ok(0)
+  |> snag.replace_error("Could not open file")
+  |> should.equal(Ok(0))
+}


### PR DESCRIPTION
This PR implements the functionality described in #10. Let me know if any changes are needed before merging. I also took a moment to update the `map_error` function documentation I added previously so that the verbiage would match the rest of the package more closely.  Cheers!